### PR TITLE
Add BitBLAS RMSNorm 2-bit quantization

### DIFF
--- a/tests/quantization/test_bitblas_rmsnorm_config.py
+++ b/tests/quantization/test_bitblas_rmsnorm_config.py
@@ -1,0 +1,8 @@
+from vllm.model_executor.layers.quantization import get_quantization_config
+from vllm.model_executor.layers.quantization.bitblas_rmsnorm import (
+    BitBLASRMSNormConfig,
+)
+
+
+def test_get_config_class():
+    assert get_quantization_config("bitblas_rmsnorm") is BitBLASRMSNormConfig

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -17,6 +17,7 @@ QuantizationMethods = Literal[
     "nvfp4",
     "marlin",
     "bitblas",
+    "bitblas_rmsnorm",
     "gguf",
     "gptq_marlin_24",
     "gptq_marlin",
@@ -87,6 +88,7 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
     from .awq import AWQConfig
     from .awq_marlin import AWQMarlinConfig
     from .bitblas import BitBLASConfig
+    from .bitblas_rmsnorm import BitBLASRMSNormConfig
     from .bitsandbytes import BitsAndBytesConfig
     from .compressed_tensors.compressed_tensors import (  # noqa: E501
         CompressedTensorsConfig)
@@ -121,6 +123,7 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
         "nvfp4": ModelOptNvFp4Config,
         "marlin": MarlinConfig,
         "bitblas": BitBLASConfig,
+        "bitblas_rmsnorm": BitBLASRMSNormConfig,
         "gguf": GGUFConfig,
         "gptq_marlin_24": GPTQMarlin24Config,
         "gptq_marlin": GPTQMarlinConfig,

--- a/vllm/model_executor/layers/quantization/bitblas_rmsnorm.py
+++ b/vllm/model_executor/layers/quantization/bitblas_rmsnorm.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+"""BitBLAS quantization with an ephemeral RMSNorm before each linear layer."""
+
+from typing import Any, Optional
+
+import torch
+
+from vllm.distributed import (
+    get_tensor_model_parallel_world_size,
+    tensor_model_parallel_all_reduce,
+)
+from vllm.model_executor.layers.linear import LinearBase
+from vllm.model_executor.layers.quantization import QuantizationMethods
+from vllm.model_executor.layers.quantization.bitblas import (
+    BitBLASConfig,
+    BitBLASLinearMethod,
+)
+
+
+class BitBLASRMSNormConfig(BitBLASConfig):
+    """BitBLAS quantization config with 2-bit weights and RMSNorm."""
+
+    def __init__(
+        self,
+        weight_bits: int = 2,
+        group_size: Optional[int] = -1,
+        desc_act: Optional[bool] = False,
+        is_sym: Optional[bool] = False,
+        quant_method: Optional[str] = "gptq",
+        lm_head_quantized: bool = False,
+    ) -> None:
+        if weight_bits != 2:
+            raise ValueError(
+                "BitBLASRMSNormConfig only supports weight_bits=2")
+        super().__init__(weight_bits, group_size, desc_act, is_sym, quant_method,
+                         lm_head_quantized)
+
+    @classmethod
+    def get_name(cls) -> QuantizationMethods:
+        return "bitblas_rmsnorm"
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> "BitBLASRMSNormConfig":
+        return cls(
+            weight_bits=config.get("bits", 2),
+            group_size=config.get("group_size", -1),
+            desc_act=config.get("desc_act", False),
+            is_sym=config.get("sym", False),
+            quant_method=config.get("quant_method", "gptq"),
+            lm_head_quantized=config.get("lm_head", False),
+        )
+
+    def get_quant_method(self, layer: torch.nn.Module,
+                         prefix: str) -> Optional["BitBLASRMSNormLinearMethod"]:
+        if isinstance(layer, LinearBase):
+            return BitBLASRMSNormLinearMethod(self)
+        return None
+
+
+class BitBLASRMSNormLinearMethod(BitBLASLinearMethod):
+    """BitBLAS linear method with pre RMSNorm."""
+
+    RMS_EPS = 1e-6
+
+    def _apply_rmsnorm(self, x: torch.Tensor) -> torch.Tensor:
+        orig_dtype = x.dtype
+        x_f32 = x.to(torch.float32)
+        tp_size = get_tensor_model_parallel_world_size()
+        if tp_size > 1:
+            local_sums = x_f32.pow(2).sum(dim=-1, keepdim=True)
+            global_sums = tensor_model_parallel_all_reduce(local_sums)
+            variance = global_sums / (tp_size * x_f32.shape[-1])
+        else:
+            variance = x_f32.pow(2).mean(dim=-1, keepdim=True)
+        x_f32 = x_f32 * torch.rsqrt(variance + self.RMS_EPS)
+        return x_f32.to(orig_dtype)
+
+    def apply_gptq(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        x = self._apply_rmsnorm(x)
+        return super().apply_gptq(layer, x, bias)
+
+    def apply(self, *args: Any, **kwargs: Any) -> torch.Tensor:
+        return self.apply_gptq(*args, **kwargs)


### PR DESCRIPTION
## Summary
- add `bitblas_rmsnorm` quantization config for BitBLAS with 2-bit weights
- implement `BitBLASRMSNormLinearMethod` that inserts a TP-aware RMSNorm before the linear
- expose the new quantization in the registry
- test that `get_quantization_config` returns the new config

## Testing
- `pre-commit` *(fails: `pre-commit: command not found`)*
- `pytest tests/quantization/test_bitblas_rmsnorm_config.py` *(fails: `pytest: command not found`)*