### PR TITLE
Rename bitblas_rmsnorm quantization

### DIFF
--- a/tests/quantization/test_bitblas_rmsnorm_config.py
+++ b/tests/quantization/test_bitblas_rmsnorm_config.py
@@ -1,8 +1,0 @@
-from vllm.model_executor.layers.quantization import get_quantization_config
-from vllm.model_executor.layers.quantization.bitblas_rmsnorm import (
-    BitBLASRMSNormConfig,
-)
-
-
-def test_get_config_class():
-    assert get_quantization_config("bitblas_rmsnorm") is BitBLASRMSNormConfig

--- a/tests/quantization/test_bitnet_config.py
+++ b/tests/quantization/test_bitnet_config.py
@@ -1,0 +1,8 @@
+from vllm.model_executor.layers.quantization import get_quantization_config
+from vllm.model_executor.layers.quantization.bitnet import (
+    BitnetConfig,
+)
+
+
+def test_get_config_class():
+    assert get_quantization_config("bitnet") is BitnetConfig

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -17,7 +17,7 @@ QuantizationMethods = Literal[
     "nvfp4",
     "marlin",
     "bitblas",
-    "bitblas_rmsnorm",
+    "bitnet",
     "gguf",
     "gptq_marlin_24",
     "gptq_marlin",
@@ -88,7 +88,7 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
     from .awq import AWQConfig
     from .awq_marlin import AWQMarlinConfig
     from .bitblas import BitBLASConfig
-    from .bitblas_rmsnorm import BitBLASRMSNormConfig
+    from .bitnet import BitnetConfig
     from .bitsandbytes import BitsAndBytesConfig
     from .compressed_tensors.compressed_tensors import (  # noqa: E501
         CompressedTensorsConfig)
@@ -123,7 +123,7 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
         "nvfp4": ModelOptNvFp4Config,
         "marlin": MarlinConfig,
         "bitblas": BitBLASConfig,
-        "bitblas_rmsnorm": BitBLASRMSNormConfig,
+        "bitnet": BitnetConfig,
         "gguf": GGUFConfig,
         "gptq_marlin_24": GPTQMarlin24Config,
         "gptq_marlin": GPTQMarlinConfig,

--- a/vllm/model_executor/layers/quantization/bitblas.py
+++ b/vllm/model_executor/layers/quantization/bitblas.py
@@ -335,7 +335,7 @@ class BitBLASLinearMethod(LinearMethodBase):
         params_dtype: torch.dtype,
         **extra_weight_attrs,
     ):
-        if self.quant_config.quant_method == "gptq":
+        if self.quant_config.quant_method in {"gptq", "bitnet", "bitblas_rmsnorm"}:
             return self.create_weights_gptq(layer, input_size_per_partition,
                                             output_partition_sizes, input_size,
                                             output_size, params_dtype,

--- a/vllm/model_executor/layers/quantization/bitnet.py
+++ b/vllm/model_executor/layers/quantization/bitnet.py
@@ -17,8 +17,8 @@ from vllm.model_executor.layers.quantization.bitblas import (
 )
 
 
-class BitBLASRMSNormConfig(BitBLASConfig):
-    """BitBLAS quantization config with 2-bit weights and RMSNorm."""
+class BitnetConfig(BitBLASConfig):
+    """BitNet quantization config with 2-bit weights and RMSNorm."""
 
     def __init__(
         self,
@@ -26,39 +26,39 @@ class BitBLASRMSNormConfig(BitBLASConfig):
         group_size: Optional[int] = -1,
         desc_act: Optional[bool] = False,
         is_sym: Optional[bool] = False,
-        quant_method: Optional[str] = "gptq",
+        quant_method: Optional[str] = "bitnet",
         lm_head_quantized: bool = False,
     ) -> None:
         if weight_bits != 2:
             raise ValueError(
-                "BitBLASRMSNormConfig only supports weight_bits=2")
+                "BitnetConfig only supports weight_bits=2")
         super().__init__(weight_bits, group_size, desc_act, is_sym, quant_method,
                          lm_head_quantized)
 
     @classmethod
     def get_name(cls) -> QuantizationMethods:
-        return "bitblas_rmsnorm"
+        return "bitnet"
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> "BitBLASRMSNormConfig":
+    def from_config(cls, config: dict[str, Any]) -> "BitnetConfig":
         return cls(
             weight_bits=config.get("bits", 2),
             group_size=config.get("group_size", -1),
             desc_act=config.get("desc_act", False),
             is_sym=config.get("sym", False),
-            quant_method=config.get("quant_method", "gptq"),
+            quant_method=config.get("quant_method", "bitnet"),
             lm_head_quantized=config.get("lm_head", False),
         )
 
     def get_quant_method(self, layer: torch.nn.Module,
-                         prefix: str) -> Optional["BitBLASRMSNormLinearMethod"]:
+                         prefix: str) -> Optional["BitnetLinearMethod"]:
         if isinstance(layer, LinearBase):
-            return BitBLASRMSNormLinearMethod(self)
+            return BitnetLinearMethod(self)
         return None
 
 
-class BitBLASRMSNormLinearMethod(BitBLASLinearMethod):
-    """BitBLAS linear method with pre RMSNorm."""
+class BitnetLinearMethod(BitBLASLinearMethod):
+    """BitNet linear method with pre RMSNorm."""
 
     RMS_EPS = 1e-6
 


### PR DESCRIPTION
## Summary
- rename `bitblas_rmsnorm` quantization to `bitnet`
- support `bitnet` and legacy `bitblas_rmsnorm` quant_method when creating weights
- update tests for the new quantization name

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest tests/quantization/test_bitnet_config.py -q` *(fails: command not found)*