### PR TITLE
Enable bitnet quantization path

### DIFF
--- a/vllm/model_executor/layers/quantization/bitblas.py
+++ b/vllm/model_executor/layers/quantization/bitblas.py
@@ -362,7 +362,7 @@ class BitBLASLinearMethod(LinearMethodBase):
         with_zeros = False
         group_size = self.quant_config.group_size
         zeros_mode = self.quant_config.zeros_mode
-        if self.quant_config.quant_method == "gptq":
+        if self.quant_config.quant_method in {"gptq", "bitnet", "bitblas_rmsnorm"}:
             with_scaling = True
             with_zeros = True
             W_dtype = f"uint{bits}"
@@ -453,7 +453,7 @@ class BitBLASLinearMethod(LinearMethodBase):
         *args: Any,
         **kwargs: Any,
     ) -> torch.Tensor:
-        if self.quant_config.quant_method == "gptq":
+        if self.quant_config.quant_method in {"gptq", "bitnet", "bitblas_rmsnorm"}:
             return self.apply_gptq(*args, **kwargs)
         else:
             raise ValueError(

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/bitblas.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/bitblas.py
@@ -216,7 +216,7 @@ class BitBLASLinearKernel(MPLinearKernel):
         with_zeros = False
         group_size = quant_config.group_size  # type: ignore[union-attr]
         zeros_mode = quant_config.zeros_mode  # type: ignore[union-attr]
-        if quant_config.quant_method == "gptq":  # type: ignore[union-attr]
+        if quant_config.quant_method in {"gptq", "bitnet", "bitblas_rmsnorm"}:  # type: ignore[union-attr]
             with_scaling = True
             with_zeros = True
             W_dtype = f"uint{bits}"


### PR DESCRIPTION
## Summary
- support bitnet and bitblas_rmsnorm in BitBLAS matmul setup
- allow bitnet quantization at runtime in mixed precision path

## Testing
- `pre-commit run --files vllm/model_executor/layers/quantization/bitblas.py vllm/model_executor/layers/quantization/kernels/mixed_precision/bitblas.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: could not connect to proxy)*